### PR TITLE
Added ability to add an employee with undo/redo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reswift-example #
 
-*README last updated Febuary 21st, 2020*
+*README last updated Febuary 23rd, 2020*
 
 ## Introduction
 
@@ -25,11 +25,12 @@ I'm just getting underway on the project, here's the laundry list of things I wa
 [x] Able to display employees assigned to a job
 [ ] Able to edit, undo/redo employee names and skills
 [ ] Able to re-order the list of employees with undo/redo
-[ ] Able to add an employee with undo/redo
+[x] Able to add an employee with undo/redo
 [ ] Able to delete an employee with undo/redo
 [ ] Able to duplicate an employee with undo/redo
 [ ] Able to move an employee from one job to another witn undo/redo
 [ ] Job document load and save
+[ ] Unit tests
 ```
 
 ### Things I'm considering changing ###

--- a/reswift-jobs/reswift-jobs.xcodeproj/project.pbxproj
+++ b/reswift-jobs/reswift-jobs.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		69723320240183CA00E91FBA /* JobWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6972331F240183CA00E91FBA /* JobWindowController.swift */; };
+		697233222402B27700E91FBA /* JobWindowTitleBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697233212402B27700E91FBA /* JobWindowTitleBarController.swift */; };
 		69AE637723F0E58900BF70EA /* Employee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AE637523F0E58900BF70EA /* Employee.swift */; };
 		69AE637C23F0E6C700BF70EA /* JobViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AE637923F0E6C600BF70EA /* JobViewController.swift */; };
 		69AE638323F0E9FD00BF70EA /* JobPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AE638123F0E9FD00BF70EA /* JobPresenter.swift */; };
@@ -41,6 +42,7 @@
 
 /* Begin PBXFileReference section */
 		6972331F240183CA00E91FBA /* JobWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JobWindowController.swift; sourceTree = "<group>"; };
+		697233212402B27700E91FBA /* JobWindowTitleBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobWindowTitleBarController.swift; sourceTree = "<group>"; };
 		69AE637523F0E58900BF70EA /* Employee.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Employee.swift; sourceTree = "<group>"; };
 		69AE637923F0E6C600BF70EA /* JobViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JobViewController.swift; sourceTree = "<group>"; };
 		69AE638123F0E9FD00BF70EA /* JobPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JobPresenter.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				69AE637923F0E6C600BF70EA /* JobViewController.swift */,
 				69AE638923F0ED1600BF70EA /* JobViewModel.swift */,
 				6972331F240183CA00E91FBA /* JobWindowController.swift */,
+				697233212402B27700E91FBA /* JobWindowTitleBarController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -286,6 +289,7 @@
 				69AE63BD23FCAC6400BF70EA /* RemoveIdempotentActionsMiddleware.swift in Sources */,
 				69AE63B123FB7C9F00BF70EA /* UndoMiddleware.swift in Sources */,
 				69AE638323F0E9FD00BF70EA /* JobPresenter.swift in Sources */,
+				697233222402B27700E91FBA /* JobWindowTitleBarController.swift in Sources */,
 				69AE63AB23FB75EC00BF70EA /* JobActions.swift in Sources */,
 				69723320240183CA00E91FBA /* JobWindowController.swift in Sources */,
 				69AE63B423FB8A5400BF70EA /* UndoCommand.swift in Sources */,

--- a/reswift-jobs/reswift-jobs/Base.lproj/Main.storyboard
+++ b/reswift-jobs/reswift-jobs/Base.lproj/Main.storyboard
@@ -842,22 +842,22 @@
             </objects>
             <point key="canvasLocation" x="-30864" y="-27734"/>
         </scene>
-        <!--Titlebar Accessory View Controller-->
+        <!--Job Window Title Bar Controller-->
         <scene sceneID="pL2-Qn-igo">
             <objects>
-                <viewController storyboardIdentifier="titlebarViewController" id="SDH-AL-SrX" customClass="NSTitlebarAccessoryViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="titlebarViewController" id="SDH-AL-SrX" customClass="JobWindowTitleBarController" customModule="reswift_jobs" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="qoK-RX-w52">
                         <rect key="frame" x="0.0" y="0.0" width="119" height="34"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Di-59-05C">
-                                <rect key="frame" x="80" y="5" width="24" height="23"/>
+                                <rect key="frame" x="80.5" y="5" width="23" height="23"/>
                                 <buttonCell key="cell" type="roundTextured" title="+" bezelStyle="texturedRounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="PpS-Qw-Q8n">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="showWorldSetting:" target="Jos-2b-X6X" id="VYS-9I-YDD"/>
+                                    <action selector="addEmployee:" target="SDH-AL-SrX" id="Ry6-XN-zoQ"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/reswift-jobs/reswift-jobs/JobDocument.swift
+++ b/reswift-jobs/reswift-jobs/JobDocument.swift
@@ -27,6 +27,7 @@ class JobDocument: NSDocument {
         let storyboard = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil)
         let windowController = storyboard.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("JobWindowController")) as! JobWindowController
         self.addWindowController(windowController)
+        windowController.store = self.store
         
         // Set the view controller's represented object as your document.
         if let contentVC = windowController.contentViewController as? JobViewController {

--- a/reswift-jobs/reswift-jobs/Model/Employee.swift
+++ b/reswift-jobs/reswift-jobs/Model/Employee.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Employee {
-    static var empty: Employee { return Employee(name: "New Employee", skills:"(skills}") }
+    static var empty: Employee { return Employee(name: "New Employee", skills:"{skills}") }
 
     let employeeID: EmployeeID
     var name: String

--- a/reswift-jobs/reswift-jobs/Model/Employee.swift
+++ b/reswift-jobs/reswift-jobs/Model/Employee.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 struct Employee {
+    static var empty: Employee { return Employee(name: "New Employee", skills:"(skills}") }
+
     let employeeID: EmployeeID
     var name: String
     var skills: String

--- a/reswift-jobs/reswift-jobs/State/Job Actions/JobActions.swift
+++ b/reswift-jobs/reswift-jobs/State/Job Actions/JobActions.swift
@@ -50,7 +50,7 @@ struct ReplaceJobAction: JobAction {
     }
 }
 
-struct InsertTaskAction: UndoableAction, JobAction {
+struct InsertEmployeeAction: UndoableAction, JobAction {
 
     let employee: Employee
     let index: Int
@@ -63,15 +63,15 @@ struct InsertTaskAction: UndoableAction, JobAction {
     }
 
     var isUndoable: Bool { return true }
-    var name: String { return "Append Task" }
+    var name: String { return "Add Employee" }
 
     func inverse(context: UndoActionContext) -> UndoableAction? {
 
-        return RemoveTaskAction(employeeID: employee.employeeID)
+        return RemoveEmployeeAction(employeeID: employee.employeeID)
     }
 }
 
-struct RemoveTaskAction: UndoableAction, JobAction {
+struct RemoveEmployeeAction: UndoableAction, JobAction {
 
     let employeeID: EmployeeID
 
@@ -83,12 +83,12 @@ struct RemoveTaskAction: UndoableAction, JobAction {
     }
 
     var isUndoable: Bool { return true }
-    var name: String { return "Remove Task" }
+    var name: String { return "Remove Employee" }
 
     func inverse(context: UndoActionContext) -> UndoableAction? {
 
         guard let removingEmployee = context.jobIn(employeeID: employeeID) else { return nil }
 
-        return InsertTaskAction(employee: removingEmployee.employee, index: removingEmployee.index)
+        return InsertEmployeeAction(employee: removingEmployee.employee, index: removingEmployee.index)
     }
 }

--- a/reswift-jobs/reswift-jobs/UI/JobViewController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobViewController.swift
@@ -66,12 +66,7 @@ class JobViewController: NSViewController {
 
        let newName = textField.stringValue
 
-       dispatchAction(RenameJobAction(renameTo: newName))
-   }
-
-   fileprivate func dispatchAction(_ action: Action) {
-
-       store?.dispatch(action)
+       store?.dispatch(RenameJobAction(renameTo: newName))
    }
 
    @objc func viewWillClose(_ notification: Notification) {
@@ -180,7 +175,7 @@ extension JobViewController: DisplaysJob {
             return .select(row: tableView.selectedRow)
         }()
 
-        dispatchAction(action)
+        store?.dispatch(action)
     }
 
  }
@@ -199,7 +194,7 @@ extension JobViewController: EmployeeItemChangeDelegate {
         let action: EmployeeAction = {
          }()
 
-        dispatchAction(action)
+        store?.dispatch(action)
 
     }
 
@@ -208,7 +203,7 @@ extension JobViewController: EmployeeItemChangeDelegate {
         guard let employeeID = EmployeeID(identifier: identifier)
             else { preconditionFailure("Invalid Employee item identifier \(identifier).") }
 
-        dispatchAction(EmployeeAction.rename(employeeID, name: name))
+        store?.dispatch(EmployeeAction.rename(employeeID, name: name))
     }
 }
 

--- a/reswift-jobs/reswift-jobs/UI/JobViewController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobViewController.swift
@@ -35,43 +35,43 @@ class JobViewController: NSViewController {
         didLoad = true
     }
 
-   /// Changing the `delegate` while the window is displayed
-   /// calls the `jobViewControllerDidLoad` callback
-   /// on the new `delegate`.
-   weak var delegate: JobViewControllerDelegate? {
-       didSet {
-           guard didLoad else { return }
+    /// Changing the `delegate` while the window is displayed
+    /// calls the `jobViewControllerDidLoad` callback
+    /// on the new `delegate`.
+    weak var delegate: JobViewControllerDelegate? {
+        didSet {
+            guard didLoad else { return }
 
-           delegate?.jobViewControllerDidLoad(self)
-       }
-   }
+            delegate?.jobViewControllerDidLoad(self)
+        }
+    }
    
-   var dataSource: EmployeeTableDataSourceType = EmployeeTableDataSource() {
-       didSet {
-           tableView.dataSource = dataSource.tableDataSource
+    var dataSource: EmployeeTableDataSourceType = EmployeeTableDataSource() {
+        didSet {
+            tableView.dataSource = dataSource.tableDataSource
 //           keyboardEventHandler?.dataSource = dataSource
        }
    }
 
-   var store: JobStore? {
+    var store: JobStore? {
 
-       didSet {
+        didSet {
 //           keyboardEventHandler?.store = store
        }
    }
 
     @IBAction func changeTitle(_ sender: AnyObject) {
 
-       guard let textField = sender as? NSTextField else { return }
+        guard let textField = sender as? NSTextField else { return }
 
-       let newName = textField.stringValue
+        let newName = textField.stringValue
 
-       store?.dispatch(RenameJobAction(renameTo: newName))
-   }
+        store?.dispatch(RenameJobAction(renameTo: newName))
+    }
 
-   @objc func viewWillClose(_ notification: Notification) {
-       delegate?.jobViewControllerWillClose(self)
-   }
+    @objc func viewWillClose(_ notification: Notification) {
+        delegate?.jobViewControllerWillClose(self)
+    }
 }
 
 protocol JobViewControllerDelegate: class {

--- a/reswift-jobs/reswift-jobs/UI/JobViewController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobViewController.swift
@@ -60,7 +60,7 @@ class JobViewController: NSViewController {
        }
    }
 
-   @IBAction func changeTitle(_ sender: AnyObject) {
+    @IBAction func changeTitle(_ sender: AnyObject) {
 
        guard let textField = sender as? NSTextField else { return }
 

--- a/reswift-jobs/reswift-jobs/UI/JobWindowController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobWindowController.swift
@@ -9,11 +9,22 @@
 import Cocoa
 
 class JobWindowController: NSWindowController {
+
+    var titlebarController: JobWindowTitleBarController?
+    
+    var store: JobStore? {
+
+        didSet {
+            titlebarController?.store = store
+        }
+    }
+       
     override func windowDidLoad() {
-        let titlebarController = self.storyboard?.instantiateController(withIdentifier:
+        titlebarController = self.storyboard?.instantiateController(withIdentifier:
             NSStoryboard.SceneIdentifier("titlebarViewController"))
-            as? NSTitlebarAccessoryViewController
+            as? JobWindowTitleBarController
         titlebarController?.layoutAttribute = .right
+
         // layoutAttribute has to be set before added to window
         self.window?.addTitlebarAccessoryViewController(titlebarController!)
     }

--- a/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
@@ -1,0 +1,24 @@
+//
+//  JobWindowTitleBarController.swift
+//  reswift-jobs
+//
+//  Created by Jay Koutavas on 2/23/20.
+//  Copyright © 2020 Heynow Software. All rights reserved.
+//
+
+import Cocoa
+
+class JobWindowTitleBarController: NSTitlebarAccessoryViewController {
+
+    var store: JobStore?
+ 
+    fileprivate func dispatchAction(_ action: Action) {
+        store?.dispatch(action)
+    }
+    
+    @IBAction func addEmployee(_ sender: AnyObject) {
+        let targetRow = store?.state.job.items.count ?? 0
+        dispatchAction(InsertEmployeeAction(employee: Employee.empty, index: targetRow))
+        dispatchAction(SelectionAction.select(row: targetRow))
+    }
+}

--- a/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
@@ -11,14 +11,10 @@ import Cocoa
 class JobWindowTitleBarController: NSTitlebarAccessoryViewController {
 
     var store: JobStore?
- 
-    fileprivate func dispatchAction(_ action: Action) {
-        store?.dispatch(action)
-    }
     
     @IBAction func addEmployee(_ sender: AnyObject) {
         let targetRow = store?.state.job.items.count ?? 0
-        dispatchAction(InsertEmployeeAction(employee: Employee.empty, index: targetRow))
-        dispatchAction(SelectionAction.select(row: targetRow))
+        store?.dispatch(InsertEmployeeAction(employee: Employee.empty, index: targetRow))
+        store?.dispatch(SelectionAction.select(row: targetRow))
     }
 }

--- a/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
+++ b/reswift-jobs/reswift-jobs/UI/JobWindowTitleBarController.swift
@@ -13,8 +13,12 @@ class JobWindowTitleBarController: NSTitlebarAccessoryViewController {
     var store: JobStore?
     
     @IBAction func addEmployee(_ sender: AnyObject) {
-        let targetRow = store?.state.job.items.count ?? 0
-        store?.dispatch(InsertEmployeeAction(employee: Employee.empty, index: targetRow))
-        store?.dispatch(SelectionAction.select(row: targetRow))
+        guard let store = store else { return }
+        let targetRow = store.state.job.items.count
+        store.dispatch(InsertEmployeeAction(employee: Employee.empty, index: targetRow))
+        
+        // TODO: One could easily argue that selection is not an action appropriate to an add button.
+        // It makes an assumption about UI rendering. Consider moving the selection to elsewhere.
+        store.dispatch(SelectionAction.select(row: targetRow))
     }
 }


### PR DESCRIPTION
I've connected the "+" button in the Job Window's title bar. The title bar's controller now signals an InsertEmployee action which in turn updates the job's employee table. 

In keeping with the Flux design pattern, the title bar controller knows nothing about the employee table's UI implementation nor its table data source.